### PR TITLE
Use new formatting rule and relative URLs

### DIFF
--- a/PAP.ffg
+++ b/PAP.ffg
@@ -3,7 +3,7 @@ let
 let
   oldDefaultNeuron = https://raw.githubusercontent.com/reuron/reuron-lib/main/defaultSwcNeuron.ffg
 let
-  newDefaultNeuron = https://raw.githubusercontent.com/hpenagos/HHmodelParms/main/defaultSwcNeuron.ffg
+  newDefaultNeuron = ./defaultSwcNeuron.ffg
 
 let
   negOne : Integer = Natural/toInteger 0 -- Natural/toInteger 1

--- a/PAPduo.ffg
+++ b/PAPduo.ffg
@@ -3,7 +3,7 @@ let
 let
   oldDefaultNeuron = https://raw.githubusercontent.com/reuron/reuron-lib/main/defaultSwcNeuron.ffg
 let
-  newDefaultNeuron = https://raw.githubusercontent.com/hpenagos/HHmodelParms/main/defaultSwcNeuron.ffg
+  newDefaultNeuron = ./defaultSwcNeuron.ffg
 
 let
   negOne : Integer = Natural/toInteger 0 -- Natural/toInteger 1

--- a/PAPsingle.ffg
+++ b/PAPsingle.ffg
@@ -3,7 +3,7 @@ let
 let
   oldDefaultNeuron = https://raw.githubusercontent.com/reuron/reuron-lib/main/defaultSwcNeuron.ffg
 let
-  newDefaultNeuron = https://raw.githubusercontent.com/hpenagos/HHmodelParms/main/defaultSwcNeuron.ffg
+  newDefaultNeuron = ./defaultSwcNeuron.ffg
 
 let
   negOne : Integer = Natural/toInteger 0 -- Natural/toInteger 1

--- a/PAPsingleLinearRamp.ffg
+++ b/PAPsingleLinearRamp.ffg
@@ -3,7 +3,7 @@ let
 let
   oldDefaultNeuron = https://raw.githubusercontent.com/reuron/reuron-lib/main/defaultSwcNeuron.ffg
 let
-  newDefaultNeuron = https://raw.githubusercontent.com/hpenagos/HHmodelParms/main/defaultSwcNeuron.ffg
+  newDefaultNeuron = ./defaultSwcNeuron.ffg
 
 let
   negOne : Integer = Natural/toInteger 0 -- Natural/toInteger 1

--- a/PAPsingleMidSectionStim.ffg
+++ b/PAPsingleMidSectionStim.ffg
@@ -3,7 +3,7 @@ let
 let
   oldDefaultNeuron = https://raw.githubusercontent.com/reuron/reuron-lib/main/defaultSwcNeuron.ffg
 let
-  newDefaultNeuron = https://raw.githubusercontent.com/hpenagos/HHmodelParms/main/defaultSwcNeuron.ffg
+  newDefaultNeuron = ./defaultSwcNeuron.ffg
 
 let
   negOne : Integer = Natural/toInteger 0 -- Natural/toInteger 1

--- a/PAPsingleSquareWave100msecPulse.ffg
+++ b/PAPsingleSquareWave100msecPulse.ffg
@@ -3,7 +3,7 @@ let
 let
   oldDefaultNeuron = https://raw.githubusercontent.com/reuron/reuron-lib/main/defaultSwcNeuron.ffg
 let
-  newDefaultNeuron = https://raw.githubusercontent.com/hpenagos/HHmodelParms/main/defaultSwcNeuron.ffg
+  newDefaultNeuron = ./defaultSwcNeuron.ffg
 
 let
   negOne : Integer = Natural/toInteger 0 -- Natural/toInteger 1

--- a/PAPsingleSquareWave1secPulse.ffg
+++ b/PAPsingleSquareWave1secPulse.ffg
@@ -3,7 +3,7 @@ let
 let
   oldDefaultNeuron = https://raw.githubusercontent.com/reuron/reuron-lib/main/defaultSwcNeuron.ffg
 let
-  newDefaultNeuron = https://raw.githubusercontent.com/hpenagos/HHmodelParms/main/defaultSwcNeuron.ffg
+  newDefaultNeuron = ./defaultSwcNeuron.ffg
 
 let
   negOne : Integer = Natural/toInteger 0 -- Natural/toInteger 1

--- a/PAPsingleSquareWave1secPulse70uV.ffg
+++ b/PAPsingleSquareWave1secPulse70uV.ffg
@@ -3,7 +3,7 @@ let
 let
   oldDefaultNeuron = https://raw.githubusercontent.com/reuron/reuron-lib/main/defaultSwcNeuron.ffg
 let
-  newDefaultNeuron = https://raw.githubusercontent.com/hpenagos/HHmodelParms/main/defaultSwcNeuron.ffg
+  newDefaultNeuron = ./defaultSwcNeuron.ffg
 
 let
   negOne : Integer = Natural/toInteger 0 -- Natural/toInteger 1

--- a/PAPsingleSquareWaveNegative100.ffg
+++ b/PAPsingleSquareWaveNegative100.ffg
@@ -3,7 +3,7 @@ let
 let
   oldDefaultNeuron = https://raw.githubusercontent.com/reuron/reuron-lib/main/defaultSwcNeuron.ffg
 let
-  newDefaultNeuron = https://raw.githubusercontent.com/hpenagos/HHmodelParms/main/defaultSwcNeuron.ffg
+  newDefaultNeuron = ./defaultSwcNeuron.ffg
 
 let
   negOne : Integer = Natural/toInteger 0 -- Natural/toInteger 1

--- a/channels.ffg
+++ b/channels.ffg
@@ -105,8 +105,8 @@ in
         magnitude: {v_at_half_max_mv: -82.0, slope: -9.0},
         time_constant: Sigmoid {
           v_at_max_tau_mv: -75.0,
-          c_base:  10e-3,
-          c_amp:  50e-3,
+          c_base:  10.0e-3,
+          c_amp:  50.0e-3,
           sigma: 20.0
         } 
       }
@@ -119,8 +119,8 @@ in
         magnitude: {v_at_half_max_mv: -90.0, slope: -8.5},
         time_constant: Sigmoid {
           v_at_max_tau_mv: -75.0,
-          c_base: 10e-3,
-          c_amp: 40e-3,
+          c_base: 10.0e-3,
+          c_amp: 40.0e-3,
           sigma:  20.0
         }
       }

--- a/defaultSwcNeuron.ffg
+++ b/defaultSwcNeuron.ffg
@@ -1,4 +1,4 @@
-let membranes = https://raw.githubusercontent.com/imalosgreg/HHmodelParms/main/membranes.ffg
+let membranes = ./membranes.ffg
 in
 
 \segments -> Neuron/neuron

--- a/defaultSwcNeuron.ffg
+++ b/defaultSwcNeuron.ffg
@@ -1,4 +1,4 @@
-let membranes = https://raw.githubusercontent.com/hpenagos/HHmodelParms/main/membranes.ffg
+let membranes = https://raw.githubusercontent.com/imalosgreg/HHmodelParms/main/membranes.ffg
 in
 
 \segments -> Neuron/neuron

--- a/membranes.ffg
+++ b/membranes.ffg
@@ -9,7 +9,7 @@ in {
   pyramidal_cell: {
 
     apical_dendrite: Neuron/membrane {
-      capacitance_farads_per_square_cm: 2e-6,
+      capacitance_farads_per_square_cm: 2.0e-6,
       membrane_channels: [
         { channel: na_transient , siemens_per_square_cm: 0.023 },
         { channel: leak , siemens_per_square_cm: 0.03e-3 },
@@ -19,7 +19,7 @@ in {
     },
 
     basal_dendrite: Neuron/membrane {
-      capacitance_farads_per_square_cm: 2e-6,
+      capacitance_farads_per_square_cm: 2.0e-6,
       membrane_channels: [
         { channel: leak , siemens_per_square_cm: 0.03e-3 },
         { channel: hcn_dendrite , siemens_per_square_cm: 0.08e-3 }
@@ -27,29 +27,29 @@ in {
     },
 
     axon_initial_segment: Neuron/membrane {
-      capacitance_farads_per_square_cm: 1e-6,
+      capacitance_farads_per_square_cm: 1.0e-6,
       membrane_channels: [
-        { channel: na_transient , siemens_per_square_cm: 120e-3 },
+        { channel: na_transient , siemens_per_square_cm: 120.0e-3 },
         { channel: leak , siemens_per_square_cm: 0.3e-3 },
-        { channel: k_slow , siemens_per_square_cm: 36e-3 }
+        { channel: k_slow , siemens_per_square_cm: 36.0e-3 }
       ]
     },
 
     axon: Neuron/membrane {
-      capacitance_farads_per_square_cm: 1e-6,
+      capacitance_farads_per_square_cm: 1.0e-6,
       membrane_channels: [
-        { channel: na_transient , siemens_per_square_cm: 120e-3 },
+        { channel: na_transient , siemens_per_square_cm: 120.0e-3 },
         { channel: leak , siemens_per_square_cm: 0.3e-3 },
-        { channel: k_slow , siemens_per_square_cm: 36e-3 }
+        { channel: k_slow , siemens_per_square_cm: 36.0e-3 }
       ]
     },
 
     soma: Neuron/membrane {
-      capacitance_farads_per_square_cm: 1e-6,
+      capacitance_farads_per_square_cm: 1.0e-6,
       membrane_channels: [
-        { channel: k_slow, siemens_per_square_cm: 36e-3 },
-        { channel: na_transient, siemens_per_square_cm: 12e-3 },
-        { channel: leak, siemens_per_square_cm: 3e-5 }
+        { channel: k_slow, siemens_per_square_cm: 36.0e-3 },
+        { channel: na_transient, siemens_per_square_cm: 12.0e-3 },
+        { channel: leak, siemens_per_square_cm: 3.0e-5 }
       ]
     }
 

--- a/membranes.ffg
+++ b/membranes.ffg
@@ -1,4 +1,4 @@
-let channels = https://raw.githubusercontent.com/hpenagos/HHmodelParms/main/channels.ffg
+let channels = ./channels.ffg
 let leak = channels.giant_squid.leak
 let k_slow = channels.rat_thalamocortical.k_slow
 let na_transient = channels.rat_thalamocortical.na_transient


### PR DESCRIPTION
There's a problem with the .ffg parser: it doesn't parse things like 10e-3 anymore, but requires 10.0e-3.

This PR fixes all number literals, and also uses internal links between files.